### PR TITLE
Remove Lucas Tétreault as editor

### DIFF
--- a/spec/did-method-spec-template.html
+++ b/spec/did-method-spec-template.html
@@ -21,15 +21,11 @@
       var respecConfig = {
         specStatus: "ED",
         editors: [{
-            name: "Lucas Tétreault",
-            url: "https://github.com/lucastetreault"
-          }, {
             name: "Jamie Jamieson",
             url: "https://github.com/jjamieson1"
           }
         ],
         processVersion: 2017,
-        edDraftURI: "https://github.com/lucastetreault/vivvo-did-spec",
         shortName: "vivvo-did-scheme"
       };
     </script>


### PR DESCRIPTION
So that I am not contacted regarding this e.g.: https://github.com/w3c/did-spec-registries/issues/174

Seems like this repo is also now a duplicate of https://github.com/Vivvo/vivvo-did-spec so you may want to just delete this and update the did spec registry.